### PR TITLE
GitHub HTTP -> HTTPS

### DIFF
--- a/sandstorm-pkgdef.capnp
+++ b/sandstorm-pkgdef.capnp
@@ -57,7 +57,7 @@ const pkgdef :Spk.PackageDefinition = (
       website = "https://github.com/zenhack/yata",
       # This should be the app's main website url.
 
-      codeUrl = "http://github.com/zenhack/yata",
+      codeUrl = "https://github.com/zenhack/yata",
       # URL of the app's source code repository, e.g. a GitHub URL.
       # Required if you specify a license requiring redistributing code, but optional otherwise.
 


### PR DESCRIPTION
So that the Report Issue button works correctly. It's fallen back to a mailto: link for you.

Fun fact: https://github.com/sandstorm-io/sandstorm/blob/f7ba095286985a0b0ca05052dd836ced2cf042db/shell/client/apps/app-details-client.js#L161 does a URL match for this, and doesn't even cover the case where someone errantly puts http:// there.